### PR TITLE
Feature/file suffixes (built on top of PR #8)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "json"]
+	path = json
+	url = https://github.com/nlohmann/json.git

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ src/fossa.o : src/fossa.c
 	g++ -c $(CFLAGS) -o src/fossa.o src/fossa.c
 
 src/IndexedMap.o : src/IndexedMap.hpp src/IndexedMap.cpp src/Datum.hpp
-	g++ -c $(CFLAGS) -o src/IndexedMap.o src/IndexedMap.cpp
+	g++ -c $(CFLAGS) -Ijson/src -o src/IndexedMap.o src/IndexedMap.cpp
 
 clean :
 	touch src/tmp.o

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #CFLAGS=-std=gnu++11 -O0 -g 
 #CFLAGS=-std=gnu++11 -O0 -ggdb -pg
 CFLAGS=-std=gnu++11 -O3
-LIBS=-lboost_iostreams
+LIBS=-lboost_iostreams -lboost_regex
 
 all : bin/lstatTree
 #all : bin/testTree
@@ -12,7 +12,7 @@ bin/lstatTree : src/lstatTree.o src/base64.o src/fossa.o src/IndexedMap.o
 bin/testHttpd: src/testHttpd.o
 	g++ -o bin/testHttpd src/testHttpd.o $(LIBS)
 
-src/lstatTree.o : src/lstatTree.cpp src/TreeNode.hpp src/Tree.hpp
+src/lstatTree.o : src/lstatTree.cpp src/TreeNode.hpp src/Tree.hpp src/IndexedMap.hpp src/Datum.hpp
 	g++ -c $(CFLAGS) -Ijson/src -o src/lstatTree.o src/lstatTree.cpp
 
 src/base64.o : src/base64.cpp src/base64.h

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ bin/testHttpd: src/testHttpd.o
 	g++ -o bin/testHttpd src/testHttpd.o $(LIBS)
 
 src/lstatTree.o : src/lstatTree.cpp src/TreeNode.hpp src/Tree.hpp
-	g++ -c $(CFLAGS) -o src/lstatTree.o src/lstatTree.cpp
+	g++ -c $(CFLAGS) -Ijson/src -o src/lstatTree.o src/lstatTree.cpp
 
 src/base64.o : src/base64.cpp src/base64.h
 	g++ -c $(CFLAGS) -o src/base64.o src/base64.cpp

--- a/src/IndexedMap.hpp
+++ b/src/IndexedMap.hpp
@@ -10,6 +10,8 @@
 #include <utility>
 #include <iostream>
 
+#include <boost/algorithm/string.hpp>
+
 #include "Datum.hpp"
 
 // nlohmann's json source library
@@ -139,8 +141,15 @@ class IndexedMap {
         json toJSON() {
 	    json j;
             for (auto it : datumMap) {
-	      std::string key = valueLookup[it.first];
-	      j[key] = it.second->toString();
+	        std::string key = valueLookup[it.first];
+		std::vector<std::string> splitKey;
+		boost::split(splitKey, key, boost::is_any_of("$"));
+		std::vector<std::string>::iterator keyParts=splitKey.begin();
+		std::string dataType = *keyParts++;
+		std::string group = *keyParts++;
+		std::string user = *keyParts++;
+		assert(keyParts == splitKey.end());
+		j[dataType][group][user] = it.second->toString();
             }
             return j;
         }

--- a/src/IndexedMap.hpp
+++ b/src/IndexedMap.hpp
@@ -12,6 +12,10 @@
 
 #include "Datum.hpp"
 
+// nlohmann's json source library
+#include "json.hpp"
+using json = nlohmann::json;
+
 // indexed map
 // since there will be a lot of repeated strings in maps throughout the
 // tree structure, there will be a single copy of each string in a static lookup table
@@ -132,21 +136,20 @@ class IndexedMap {
 			}
         }
 
-        std::string toJSON() {
-            std::ostringstream oss;
-            std::string comma="";
+        json toJSON() {
+	    json j;
             for (auto it : datumMap) {
-                oss << comma << "\"" << valueLookup[it.first]<< "\": " << it.second->toString();
-                comma=", ";
+	      std::string key = valueLookup[it.first];
+	      j[key] = it.second->toString();
             }
-            return oss.str();
+            return j;
         }
         
-        std::string toJSON(std::string item) {
-            std::ostringstream oss;
-            uint64_t index=keyLookup[item];
-            oss << "\"" << item << "\": " << datumMap.at(index)->toString();
-            return oss.str();
+        json toJSON(std::string item) {
+	    json j;
+	    uint64_t index=keyLookup[item];
+	    j[item] = datumMap.at(index)->toString();
+            return j;
         }
         
         std::string getIndex() {
@@ -157,16 +160,10 @@ class IndexedMap {
             return oss.str();
         }
         
-        std::string keysJSON() {
-            std::ostringstream oss;
-            oss << "{ \"attributes\": [";
-            std::string comma="";
-            for (auto it : keyLookup) {
-                oss << comma << "\"" << it.first << "\"";
-                comma=",";
-            }
-            oss << "]}";
-            return oss.str();
+        json keysJSON() {
+	    json j;
+            j["attributes"] = keyLookup;
+            return j;
         }        
 
         bool empty() {

--- a/src/IndexedMap.hpp
+++ b/src/IndexedMap.hpp
@@ -35,20 +35,20 @@ class IndexedMap {
     public :
         // default constructor - just creates an empty map ready to fill
         IndexedMap() : datumMap() {}
-		~IndexedMap() {
+                ~IndexedMap() {
             std::unordered_map<uint64_t, Datum*>::iterator it;
-			for (it=datumMap.begin(); it != datumMap.end(); it++) {
-				delete it->second;
-			}
-			datumMap.clear();
-		}
+                        for (it=datumMap.begin(); it != datumMap.end(); it++) {
+                                delete it->second;
+                        }
+                        datumMap.clear();
+                }
 
-		// copy constructor
-		IndexedMap(const IndexedMap& im) : datumMap() {
-			for (auto it : im.datumMap) {
-				datumMap.insert(std::make_pair(it.first, new Datum(*(it.second))));
-			}
-		}
+                // copy constructor
+                IndexedMap(const IndexedMap& im) : datumMap() {
+                        for (auto it : im.datumMap) {
+                                datumMap.insert(std::make_pair(it.first, new Datum(*(it.second))));
+                        }
+                }
 
         template <typename T>
         void addItem(std::string key, T val) {
@@ -115,10 +115,10 @@ class IndexedMap {
         }
 
         void subtract(IndexedMap& other) {
-			// remove vector
-			std::vector<std::unordered_map<uint64_t, Datum*>::iterator> remove;
+                        // remove vector
+                        std::vector<std::unordered_map<uint64_t, Datum*>::iterator> remove;
             // loop over datums in this map
- 			std::unordered_map<uint64_t, Datum*>::iterator it;
+                         std::unordered_map<uint64_t, Datum*>::iterator it;
             for (it=datumMap.begin(); it != datumMap.end(); it++) {
                 // get the index and datum
                 uint64_t index=it->first;
@@ -127,37 +127,39 @@ class IndexedMap {
                 std::unordered_map<uint64_t, Datum*>::iterator got = other.datumMap.find(index);
                 if (got != other.datumMap.end()) {
                     it->second->sub(*(got->second));
-					if (it->second->isZero()) {
-						remove.push_back(it);
-					}
+                                        if (it->second->isZero()) {
+                                                remove.push_back(it);
+                                        }
                 }
             }
-			for (auto it : remove) {
-				delete it->second;
-				datumMap.erase(it);
-			}
+                        for (auto it : remove) {
+                                delete it->second;
+                                datumMap.erase(it);
+                        }
         }
 
         json toJSON() {
-	    json j;
+            json j;
             for (auto it : datumMap) {
-	        std::string key = valueLookup[it.first];
-		std::vector<std::string> splitKey;
-		boost::split(splitKey, key, boost::is_any_of("$"));
-		std::vector<std::string>::iterator keyParts=splitKey.begin();
-		std::string dataType = *keyParts++;
-		std::string group = *keyParts++;
-		std::string user = *keyParts++;
-		assert(keyParts == splitKey.end());
-		j[dataType][group][user] = it.second->toString();
+                std::string key = valueLookup[it.first];
+                std::vector<std::string> splitKey;
+                boost::split(splitKey, key, boost::is_any_of("$"));
+                std::vector<std::string>::iterator keyParts=splitKey.begin();
+                std::string dataType = *keyParts++;
+                std::string group = *keyParts++;
+                std::string user = *keyParts++;
+                std::string property = *keyParts++;
+                //std::cerr << "toJSON:" << key << " ==> " << dataType << "," << group << "," << user << "," << property << "!" << std::endl;
+                assert(keyParts == splitKey.end());
+                j[dataType][group][user][property] = it.second->toString();
             }
             return j;
         }
         
         json toJSON(std::string item) {
-	    json j;
-	    uint64_t index=keyLookup[item];
-	    j[item] = datumMap.at(index)->toString();
+            json j;
+            uint64_t index=keyLookup[item];
+            j[item] = datumMap.at(index)->toString();
             return j;
         }
         
@@ -170,7 +172,7 @@ class IndexedMap {
         }
         
         json keysJSON() {
-	    json j;
+            json j;
             j["attributes"] = keyLookup;
             return j;
         }        

--- a/src/Tree.hpp
+++ b/src/Tree.hpp
@@ -8,9 +8,6 @@
 
 #include "TreeNode.hpp"
 
-#include "json.hpp"
-using json = nlohmann::json;
-
 class Tree {
     
     public :
@@ -81,23 +78,22 @@ class Tree {
 	    }
         }
         
-        std::string toJSON(std::string path, uint64_t d=std::numeric_limits<uint64_t>::max()) {
+        json toJSON(std::string path, uint64_t d=std::numeric_limits<uint64_t>::max()) {
 	    json j;
             if (d==0) d=1;
             TreeNode *tmp=getNodeAt(path);
 	    if (tmp == NULL) {
 	      j =  json::object();
 	    } else {
-	      j = json::parse(tmp->toJSON(d,0));
+	      j = tmp->toJSON(d,0);
 	    }
-	    // pretty print json with 2 spaces per indent level
-	    return j.dump(2);
+	    return j;
         }
-        std::string toJSON(uint64_t d) {
+        json toJSON(uint64_t d) {
             if (d==0) d=1;
             return root->toJSON(d,0);
         }
-        std::string toJSON() {
+        json toJSON() {
             return root->toJSON(std::numeric_limits<uint64_t>::max(),0);
         }    
     private:

--- a/src/Tree.hpp
+++ b/src/Tree.hpp
@@ -73,21 +73,21 @@ class Tree {
         // i.e. size of files within the directory itself. this will be calculated by
         // summing the sizes of all children and subtracting from the size of the node
         void finalize() {
-	    if (root != NULL) {
-	      root->finalize();
-	    }
+            if (root != NULL) {
+              root->finalize();
+            }
         }
         
         json toJSON(std::string path, uint64_t d=std::numeric_limits<uint64_t>::max()) {
-	    json j;
+            json j;
             if (d==0) d=1;
             TreeNode *tmp=getNodeAt(path);
-	    if (tmp == NULL) {
-	      j =  json::object();
-	    } else {
-	      j = tmp->toJSON(d,0);
-	    }
-	    return j;
+            if (tmp == NULL) {
+              j =  json::object();
+            } else {
+              j = tmp->toJSON(d,0);
+            }
+            return j;
         }
         json toJSON(uint64_t d) {
             if (d==0) d=1;

--- a/src/Tree.hpp
+++ b/src/Tree.hpp
@@ -8,6 +8,9 @@
 
 #include "TreeNode.hpp"
 
+#include "json.hpp"
+using json = nlohmann::json;
+
 class Tree {
     
     public :
@@ -79,13 +82,16 @@ class Tree {
         }
         
         std::string toJSON(std::string path, uint64_t d=std::numeric_limits<uint64_t>::max()) {
+	    json j;
             if (d==0) d=1;
             TreeNode *tmp=getNodeAt(path);
 	    if (tmp == NULL) {
-	      return "{}";
+	      j =  json::object();
 	    } else {
-	      return tmp->toJSON(d,0);
+	      j = json::parse(tmp->toJSON(d,0));
 	    }
+	    // pretty print json with 2 spaces per indent level
+	    return j.dump(2);
         }
         std::string toJSON(uint64_t d) {
             if (d==0) d=1;

--- a/src/TreeNode.hpp
+++ b/src/TreeNode.hpp
@@ -14,6 +14,10 @@
 #include "IndexedMap.hpp"
 #include "Datum.hpp"
 
+// nlohmann's json source library
+#include "json.hpp"
+using json = nlohmann::json;
+
 class TreeNode {
 
     public :
@@ -78,7 +82,7 @@ class TreeNode {
             return tmp;
         }
         
-        std::string toJSON(uint64_t d, uint64_t s=0) {
+        json toJSON(uint64_t d, uint64_t s=0) {
             std::stringstream oss;
             std::string space="";
             for (int i=0; i<s; i++) {
@@ -103,7 +107,7 @@ class TreeNode {
                 oss << space << "]" << std::endl;
             }
             oss << space << "}" << std::endl;
-            return oss.str();       
+            return json::parse(oss.str());
         }
 
         // adds a *.* to the children of a node

--- a/src/TreeNode.hpp
+++ b/src/TreeNode.hpp
@@ -26,12 +26,12 @@ class TreeNode {
                 depth=0;
             }
         }
-		~TreeNode() {
-			std::unordered_map<std::string,TreeNode*>::iterator it;
-			for (it=children.begin(); it != children.end(); it++) {
-				delete it->second;
-			}
-		}
+                ~TreeNode() {
+                        std::unordered_map<std::string,TreeNode*>::iterator it;
+                        for (it=children.begin(); it != children.end(); it++) {
+                                delete it->second;
+                        }
+                }
 
         std::string getName() {
             return name;
@@ -79,21 +79,21 @@ class TreeNode {
         }
         
         json toJSON(uint64_t d, uint64_t s=0) {
-	  json j;
+          json j;
 
-	  j["name"] = name;
-	  j["path"] = getPath();
-	  j["data"] = data.toJSON();
-	  
-	  if ( d > 0 && (!children.empty()) ) {
-	    json child_dirs;
-	    std::unordered_map< std::string, TreeNode* >::iterator it;
-	    for (it=children.begin(); it != children.end(); it++) {
-	      child_dirs.push_back(((*it).second)->toJSON(d-1,s));
-	    }
-	    j["child_dirs"] = child_dirs;
-	  }
-	  return j;
+          j["name"] = name;
+          j["path"] = getPath();
+          j["data"] = data.toJSON();
+          
+          if ( d > 0 && (!children.empty()) ) {
+            json child_dirs;
+            std::unordered_map< std::string, TreeNode* >::iterator it;
+            for (it=children.begin(); it != children.end(); it++) {
+              child_dirs.push_back(((*it).second)->toJSON(d-1,s));
+            }
+            j["child_dirs"] = child_dirs;
+          }
+          return j;
         }
   
         // adds a *.* to the children of a node
@@ -103,26 +103,26 @@ class TreeNode {
         // don't have to call this server side - it might be better to let
         // the client side work it all out purely from the JSON
         void finalize() {
-	  // create an clone of the current indexed map
-	  IndexedMap im(data);
-	  
-	  if (!children.empty()) {
-	    // loop over children and subtract all their maps from it
-	    for (auto it : children) {
-	      it.second->finalize();
-	      im.subtract(it.second->data);
-	    }
-	  }
+          // create an clone of the current indexed map
+          IndexedMap im(data);
+          
+          if (!children.empty()) {
+            // loop over children and subtract all their maps from it
+            for (auto it : children) {
+              it.second->finalize();
+              im.subtract(it.second->data);
+            }
+          }
 
-	  if (! im.empty() ) {
+          if (! im.empty() ) {
 #ifndef NDEBUG
-	    std::cout << "creating *.* child at " << getPath() << std::endl;
+            std::cout << "creating *.* child at " << getPath() << std::endl;
 #endif
-	    TreeNode *child = new TreeNode("*.*", this);
-	    child->combine(im);
-	    addChild(child);
-	  } 
-	  
+            TreeNode *child = new TreeNode("*.*", this);
+            child->combine(im);
+            addChild(child);
+          } 
+          
         }
     
     private:

--- a/src/TreeNode.hpp
+++ b/src/TreeNode.hpp
@@ -14,10 +14,6 @@
 #include "IndexedMap.hpp"
 #include "Datum.hpp"
 
-// nlohmann's json source library
-#include "json.hpp"
-using json = nlohmann::json;
-
 class TreeNode {
 
     public :
@@ -83,33 +79,23 @@ class TreeNode {
         }
         
         json toJSON(uint64_t d, uint64_t s=0) {
-            std::stringstream oss;
-            std::string space="";
-            for (int i=0; i<s; i++) {
-                space+="  ";
-            }
-            ++s;
-            oss << space << "{" << std::endl;
-	    oss << space << "\"name\": \"" << name << "\", " << "\"path\": \"" << getPath() << "\", " << data.toJSON() << std::endl;
-            --d;
-            if ( d > 0 && (!children.empty()) ) {
-                oss << space << ", \"child_dirs\": [" << std::endl;
-                bool sep=false;
-                std::unordered_map< std::string, TreeNode* >::iterator it;
-                for (it=children.begin(); it != children.end(); it++) {
-                    if (sep) {
-                        oss << space << "," << std::endl;;
-                        sep=true;
-                    }
-                    oss << ((*it).second)->toJSON(d,s);
-                    sep=",";
-                }
-                oss << space << "]" << std::endl;
-            }
-            oss << space << "}" << std::endl;
-            return json::parse(oss.str());
-        }
+	  json j;
 
+	  j["name"] = name;
+	  j["path"] = getPath();
+	  j["data"] = data.toJSON();
+	  
+	  if ( d > 0 && (!children.empty()) ) {
+	    json child_dirs;
+	    std::unordered_map< std::string, TreeNode* >::iterator it;
+	    for (it=children.begin(); it != children.end(); it++) {
+	      child_dirs.push_back(((*it).second)->toJSON(d-1,s));
+	    }
+	    j["child_dirs"] = child_dirs;
+	  }
+	  return j;
+        }
+  
         // adds a *.* to the children of a node
         // this calculates an indexed map which is the combination of
         // all the child indexed maps, and gives the result of subtracting

--- a/src/lstatTree.cpp
+++ b/src/lstatTree.cpp
@@ -280,7 +280,7 @@ int main(int argc, char **argv) {
     std::cout << "Built tree in " << time(0)-now << " seconds" << std::endl;
 #ifndef NDEBUG
 	std::cout << "in debug section, printing out tree and exiting" << std::endl;
-    std::cout << tree->toJSON();
+	std::cout << std::setw(2) << tree->toJSON() << std::endl;
     // tidy up and stop - want to bail out here to gperf the tree construction
     // top optimize it and to make sure it passes valgrind without issue
     delete tree;

--- a/src/lstatTree.cpp
+++ b/src/lstatTree.cpp
@@ -144,17 +144,18 @@ void addAttribute(IndexedMap &im, std::string attr_name, T attr_val) {
 }
 
 template<typename T>
-void addAttribute(IndexedMap &im, std::string attr_name, T attr_val, std::string uid_str) {
+void addAttribute(IndexedMap &im, std::string attr_name, T attr_val, std::string gid_str, std::string uid_str) {
     std::ostringstream oss;
-    oss << attr_name << uid_str;
+    oss << attr_name << "$" << gid_str << "$" << uid_str;
     im.addItem(oss.str(),attr_val);
 }
 
 template<typename T>
-void addAttribute(IndexedMap &im, std::string attr_name, T attr_val, std::string gid_str, std::string uid_str) {
-    std::ostringstream oss;
-    oss << attr_name << gid_str << "_" << uid_str;
-    im.addItem(oss.str(),attr_val);
+void addAttributes(IndexedMap &im, std::string attr_name, T attr_val, std::string grp, std::string usr) {
+    addAttribute(im, attr_name, attr_val, "*", "*");
+    addAttribute(im, attr_name, attr_val, "*", usr);
+    addAttribute(im, attr_name, attr_val, grp, "*");
+    addAttribute(im, attr_name, attr_val, grp, usr);
 }
 
 int main(int argc, char **argv) {
@@ -231,37 +232,22 @@ int main(int argc, char **argv) {
         // add atributes to the im...
 
         // inode counts
-        addAttribute(im,"count",static_cast<uint64_t>(1));
-        addAttribute(im,"count_by_uid_",static_cast<uint64_t>(1),owner);
-        addAttribute(im,"count_by_gid_",static_cast<uint64_t>(1),grp);
-        addAttribute(im,"count_by_gid_uid_",static_cast<uint64_t>(1),grp,owner);
+        addAttributes(im, "count", static_cast<uint64_t>(1), grp, owner);
 
         // size related
-        addAttribute(im,"size",size);
-        addAttribute(im,"size_by_uid_",size,owner);
-        addAttribute(im,"size_by_gid_",size,grp);
-        addAttribute(im,"size_by_gid_uid_",size,grp,owner);
+        addAttributes(im, "size", size, grp, owner);
         
         // atime related
         double atime_cost=cost_per_tib_year*tib*atime_years;
-        addAttribute(im,"atime_cost",atime_cost);
-        addAttribute(im,"atime_cost_by_uid_",atime_cost,owner);
-        addAttribute(im,"atime_cost_by_gid_",atime_cost,grp);
-        addAttribute(im,"atime_cost_by_gid_uid_",atime_cost,grp,owner);
+        addAttributes(im, "atime", atime_cost, grp, owner);
 
         // mtime related
         double mtime_cost=cost_per_tib_year*tib*mtime_years;
-        addAttribute(im,"mtime_cost",mtime_cost);
-        addAttribute(im,"mtime_cost_by_uid_",mtime_cost,owner);
-        addAttribute(im,"mtime_cost_by_gid_",mtime_cost,grp);
-        addAttribute(im,"mtime_cost_by_gid_uid_",mtime_cost,grp,owner);
+        addAttributes(im, "mtime", mtime_cost, grp, owner);
 
         // ctime related
         double ctime_cost=cost_per_tib_year*tib*ctime_years;
-        addAttribute(im,"ctime_cost",ctime_cost);
-        addAttribute(im,"ctime_cost_by_uid_",ctime_cost,owner);
-        addAttribute(im,"ctime_cost_by_gid_",ctime_cost,grp);
-        addAttribute(im,"ctime_cost_by_gid_uid_",ctime_cost,grp,owner);
+        addAttributes(im, "ctime", ctime_cost, grp, owner);
 
         // TODO : file suffix related (bams, vcfs etc)
 

--- a/src/lstatTree.cpp
+++ b/src/lstatTree.cpp
@@ -112,13 +112,13 @@ static void handle_sum_call(struct ns_connection *nc, struct http_message *hm) {
     std::cout << "path=" << path << ", depth=" << d << std::endl;
     
     // get JSON
-    std::string result=tree->toJSON(std::string(path),d+1);
+    json result = tree->toJSON(std::string(path), d+1);
 
     /* Send headers */
     ns_printf(nc, "%s", "HTTP/1.1 200 OK\r\nAccess-Control-Allow-Origin: *\r\nTransfer-Encoding: chunked\r\n\r\n");
     
-    // send json
-    ns_printf_http_chunk(nc, "%s", result.c_str());
+    // send json -- pretty printed with 2 spaces per indent level
+    ns_printf_http_chunk(nc, "%s", result.dump(2).c_str()); 
     ns_send_http_chunk(nc, "", 0);  /* Send empty chunk, the end of response */
 }
 

--- a/src/testIndexedMap.cpp
+++ b/src/testIndexedMap.cpp
@@ -46,7 +46,7 @@ int main(int argc, char **argv) {
     // print out the static indexing map
     std::cout << "indexing map : " << std::endl;
     std::cout << im1->getIndex() << std::endl;
-	delete im1;
-	delete im2;
+        delete im1;
+        delete im2;
     return 0;
 }

--- a/src/testTreeNode.cpp
+++ b/src/testTreeNode.cpp
@@ -29,7 +29,7 @@ int main(int argc, char **argv) {
     TreeNode *tmp=new TreeNode("b",tree);
     tmp->combine(im2);
     std::cout << tree->toJSON(2,0) << std::endl;
-	tree->finalize();
-	delete tree;
+        tree->finalize();
+        delete tree;
     return 0;
 }


### PR DESCRIPTION
This implements regex based file "property" functionality and includes a set of regexes for: cram, bam, index, compressed, uncompressed, checkpoint, and temporary. Files not matching any regexes are assigned to: other. Properties are also added for file type (directory, file, link, or type_X). The catch-all property `*` is assigned to all files. 

These properties are added to the JSON data structure after the user. So access to a data value within a node would now be via:
`node.data.<MEASURE>.<GROUP>.<USER>.<PROPERTY>`

For example: `node.data.size.*.*.uncompressed` would give the size of all uncompressed data (as defined by the uncompressed regex) under that node. 
